### PR TITLE
一旦見送り

### DIFF
--- a/app/assets/javascripts/summernote-init.coffee
+++ b/app/assets/javascripts/summernote-init.coffee
@@ -1,4 +1,5 @@
 $(document).on 'turbolinks:load', ->
   $('[data-provider="summernote"]').each ->
     $(this).summernote
+      lang: 'ja-JP'
       height: 730

--- a/app/assets/stylesheets/posts/_new.scss
+++ b/app/assets/stylesheets/posts/_new.scss
@@ -119,3 +119,7 @@
     box-shadow: 0 0 1px gray;
   }
 }
+
+.note-btn-group.btn-group.note-insert{
+  display: none;
+}


### PR DESCRIPTION
# WHAT
画像投稿をできないように設定。
# WHY
画像投稿の参考資料が見つからなかったので、一旦保留
投稿すると、画像が長い文字列に変換されてしまい、カラムの容量を超えるので、一旦投稿ボタンを隠しました。